### PR TITLE
Remove view operation to avoid row vector crash

### DIFF
--- a/sparsemax/sparsemax.py
+++ b/sparsemax/sparsemax.py
@@ -48,7 +48,7 @@ class SparsemaxFunction(torch.autograd.Function):
         input = input - input.max(-1, keepdim=True).values.expand_as(input)
 
         zs = input.sort(-1, descending=True).values
-        range = torch.arange(1, input.size()[-1] + 1).view(1, -1)
+        range = torch.arange(1, input.size()[-1] + 1)
         range = range.expand_as(input).to(input)
 
         # Determine sparsity of projection


### PR DESCRIPTION
Hello,

First of all thanks for the implementation!
I think I found a very minor bug in the code that doesn't allow Sparsemax to run on row vectors.

The behavior can be replicated like this:
```python
import torch
from sparsemax import Sparsemax

x = torch.randn(10)
sparsemax = Sparsemax()

sparsemax(x)
```
which triggers an error when trying to expand the variable `range` to be the same size as `x`. This happens because `range` has a bigger shape than `x`.

In this PR I'm just removing the call to `view(1, -1)` after creating `range` to contemplate the corner case.